### PR TITLE
update addCouncilStyle to move zoom feature to the top right of a map…

### DIFF
--- a/R/addCouncilStyle.R
+++ b/R/addCouncilStyle.R
@@ -21,9 +21,14 @@ addCouncilStyle <- function(map, add_dists = FALSE, highlight_dists = NULL, dist
                             highlight_color = "#cdd9f1", minZoom = 10, maxZoom = 15) {
 
   map <-  map %>%
-    leaflet(options = leafletOptions(minZoom = minZoom, maxZoom = maxZoom)) %>%
+    leaflet(options = leafletOptions(minZoom = minZoom,
+                                     maxZoom = maxZoom,
+                                     zoomControl = FALSE)) %>%
     setView(-73.984865, 40.710542, zoom = 11) %>%
-    leaflet.extras::setMapWidgetStyle(list(background = "white"))
+    leaflet.extras::setMapWidgetStyle(list(background = "white")) %>%
+    htmlwidgets::onRender("function(el, x) {
+        L.control.zoom({ position: 'topright' }).addTo(this)
+    }")
 
 
   if(add_dists) {


### PR DESCRIPTION
…, instead of the top left where most legends tend to fall under

<img width="780" alt="image" src="https://github.com/NewYorkCityCouncil/councildown/assets/44377052/3e0b2115-1b5b-4b13-b163-8bbac54e1e16">


![image](https://github.com/NewYorkCityCouncil/councildown/assets/44377052/87dd20bd-914b-4ea9-9375-6ac810a29fad)
