### PR TITLE
adding sf to 'suggests' & mapview to 'imports' sections in description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,9 @@ Imports: bookdown,
     htmlwidgets,
     magrittr,
     knitr,
-    dplyr (>= 0.8)
+    dplyr (>= 0.8),
+    mapview
 Suggests: here,
-    extrafont
+    extrafont,
+    sf
 RoxygenNote: 7.2.3


### PR DESCRIPTION
I think we still will get the sp -- rgeo/rgdal retiring message because mapview hasn't updated their description file to only accept sp (>= 2.0) where retiring packages aren't used anymore, have been switched to sf.

https://github.com/r-spatial/mapview/blob/master/DESCRIPTION

Not sure if we add sf to the suggests section if that will quiet the error...

And here says that the message will clear in October .....
https://cran.r-project.org/web/packages/sp/index.html

> From this version, evolution status is set to '2L' using 'sf' in place of 'rgdal', see <https://r-spatial.org/r/2023/05/15/evolution4.html> for details. Retiring packages 'maptools', 'rgdal' and 'rgeos' will be dropped by October 2023.

https://github.com/edzer/sp/issues