### PR TITLE
colorBin adjustment for palettes

### DIFF
--- a/R/addCouncilStyle.R
+++ b/R/addCouncilStyle.R
@@ -128,8 +128,9 @@ colorBin <- function(palette = "nycc_blue", domain = NULL,
   if((length(bins) == 1 & bins[1] > 7) | length(bins) > 7){
     cli::cli_abort("Can't create color mapping with more than 7 bins")
   }
+  palette <- if(!is.null(councildown::pal_nycc(palette))) {councildown::pal_nycc(palette)} else {palette}
   leaflet::colorBin(
-    palette = ifelse(!is.null(councildown:::nycc_palettes[[palette]]), councildown::pal_nycc(palette), palette),
+    palette = palette,
     na.color = na.color,
     bins = bins,
     domain = domain

--- a/R/addCouncilStyle.R
+++ b/R/addCouncilStyle.R
@@ -129,7 +129,7 @@ colorBin <- function(palette = "nycc_blue", domain = NULL,
     cli::cli_abort("Can't create color mapping with more than 7 bins")
   }
   leaflet::colorBin(
-    palette = ifelse(!is.null(nycc_palettes[[palette]]), councildown::pal_nycc(palette), palette),
+    palette = ifelse(!is.null(councildown:::nycc_palettes[[palette]]), councildown::pal_nycc(palette), palette),
     na.color = na.color,
     bins = bins,
     domain = domain

--- a/R/addCouncilStyle.R
+++ b/R/addCouncilStyle.R
@@ -129,7 +129,7 @@ colorBin <- function(palette = "nycc_blue", domain = NULL,
     cli::cli_abort("Can't create color mapping with more than 7 bins")
   }
   leaflet::colorBin(
-    palette = councildown::pal_nycc(palette),
+    palette = ifelse(!is.null(nycc_palettes[[palette]]), councildown::pal_nycc(palette), palette),
     na.color = na.color,
     bins = bins,
     domain = domain


### PR DESCRIPTION
Previously colorBin assumed palettes were chosen from the nycc_palette list. Now it checks whether or not the `palette = ` input is in the nycc_palette list and if not, it proceeds as normal. For example, it can now accept `"Blues"` palette from [Color Brewer 2](http://colorbrewer2.org/)